### PR TITLE
Symfony 4 compatibility

### DIFF
--- a/Security/CasFactory.php
+++ b/Security/CasFactory.php
@@ -6,18 +6,18 @@ namespace L3\Bundle\CasBundle\Security;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Reference;
 
 class CasFactory implements SecurityFactoryInterface {
     public function create(ContainerBuilder $container, $id, $config, $userProvider, $defaultEntryPoint) {
         $providerId = 'security.authentication.provider.cas.'.$id;
         $container
-            ->setDefinition($providerId, new DefinitionDecorator('cas.security.authentication.provider'))
+            ->setDefinition($providerId, new ChildDefinition('cas.security.authentication.provider'))
             ->replaceArgument(0, new Reference($userProvider));
 
         $listenerId = 'security.authentication.listener.cas.'.$id;
-        $listener = $container->setDefinition($listenerId, new DefinitionDecorator('cas.security.authentication.listener'));
+        $listener = $container->setDefinition($listenerId, new ChildDefinition('cas.security.authentication.listener'));
 
         return array($providerId, $listenerId, $defaultEntryPoint);
     }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": ">=5.4",
         "jasig/phpcas": "~1.3",
-	"symfony/symfony": "~3.3 || ~4.0"
+	"symfony/symfony": "~3.3 || ~4.0",
+        "symfony/security-bundle": "~3.3 || ~4.0"
     },
     "autoload": {
         "psr-4": { "L3\\Bundle\\CasBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.4",
         "jasig/phpcas": "~1.3",
-	"symfony/symfony": "~3.3"
+	"symfony/symfony": "~3.3 || ~4.0"
     },
     "autoload": {
         "psr-4": { "L3\\Bundle\\CasBundle\\": "" }


### PR DESCRIPTION
- Added the security bundle dependency
- Changed the class name from a deprecated class (introduced in 3.3 so no BC break)
- Updated minimum version of Symfony to include anything in the 4.x range