### PR TITLE
Implement symfony firewall logout `success_handler`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,29 @@ You can also use FOSUserBundle... like this :
             id: fos_user.user_provider.username
 ```
 
+Logout Handler
+---
+In Symfony 2 and Symfony 3, setup a [logout route](#logout-route). For Symfony 4+, add the following to your **security.yml**:
+```yml
+security:
+    providers:
+            # ...
+
+
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+
+        l3_firewall:
+            pattern: ^/
+            security: true
+            cas: true # Activation du CAS
+            logout:
+                path: logout
+                success_handler: cas.security.logout.success_handler
+```
+
 Logout route
 ---
 In Symfony 2 or Symfony 3, if you want use **/logout** route in order to call Logout, you can add this in your **routing.yml** :
@@ -362,7 +385,7 @@ l3_logout:
     defaults: { _controller: L3CasBundle:Logout:logout }
 ```
 
-In Symfony 4, you can add this in your **routes.yaml** :
+In Symfony 4, its recommended to use a logout `success_handler` instead of using a route. But, if you need a route you can add this in your **routes.yaml** :
 ```
 logout:
     path: /logout

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,3 +8,8 @@ services:
         class: L3\Bundle\CasBundle\Security\CasListener
         arguments: ['@security.token_storage', '@security.authentication.manager', '%cas%']
         public: false
+
+    cas.security.logout.success_handler:
+        class: L3\Bundle\CasBundle\Security\CasLogoutSuccessHandler
+        arguments: ['%cas%']
+        public: false

--- a/Security/CasLogoutSuccessHandler.php
+++ b/Security/CasLogoutSuccessHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace L3\Bundle\CasBundle\Security;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
+
+/**
+ * Handles successfully logging out of symfony.
+ *
+ * Forces logging out of cas if required.
+ */
+class CasLogoutSuccessHandler implements LogoutSuccessHandlerInterface
+{
+    protected $casConfig;
+
+    /*
+     * Create handler instance.
+     *
+     * @param array $cas_config
+     *   Cas config parameter.
+     */
+    public function __construct(array $cas_config)
+    {
+        $this->casConfig = $cas_config;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onLogoutSuccess(Request $request): Response
+    {
+        if(!empty($this->casConfig['casLogoutTarget'])) {
+            \phpCas::logoutWithRedirectService($this->casConfig['casLogoutTarget']);
+        } else {
+            \phpCAS::logout();
+        }
+    }
+}


### PR DESCRIPTION
In the Symfony docs, its recommended to implement logout events by specifying a `logout.success_handler` for the firewall. This project should supply a handler for use in applications.

In the [Symfony Security](https://symfony.com/doc/current/security.html#logging-out) documentation it recommends the following.

> Need more control of what happens after logout? Add a success_handler key under logout and point it to a service id of a class that implements [`LogoutSuccessHandlerInterface`](https://github.com/symfony/symfony/blob/4.3/src/Symfony/Component/Security/Http/Logout/LogoutSuccessHandlerInterface.php).