### PR TITLE
300 was integer, not string, while string was required

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,7 +20,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('l3_cas');
         $treeBuilder->getRootNode()
             ->children()
-            ->scalarNode('host')->defaultValue(300)->end()
+            ->scalarNode('host')->defaultValue('please-configure-cas-host')->end()
             ->scalarNode('path')->defaultValue('')->end()
             ->scalarNode('port')->defaultValue(443)->end()
             ->scalarNode('ca')->defaultNull()->end()


### PR DESCRIPTION
While creating new Symfony 5 application I've encountered quite cryptic:

    phpCAS::client(): CAS_TypeMismatchException: type mismatched for parameter $server_hostname (should be 'string '), integer given.

so here's simple fix for that. Don't know where that `300` came from, doesn't make any sense.