### PR TITLE
Add support for phpCAS 1.6.0

### DIFF
--- a/Security/CasListener.php
+++ b/Security/CasListener.php
@@ -26,7 +26,7 @@ class CasListener {
 
         \phpCAS::setDebug(false);
 
-        \phpCAS::client(CAS_VERSION_2_0, $this->getParameter('host'), $this->getParameter('port'), is_null($this->getParameter('path')) ? '' : $this->getParameter('path'), true);
+        \phpCAS::client(CAS_VERSION_2_0, $this->getParameter('host'), $this->getParameter('port'), is_null($this->getParameter('path')) ? '' : $this->getParameter('path'), $event->getRequest()->getSchemeAndHttpHost(), true);
 
         if(is_bool($this->getParameter('ca')) && $this->getParameter('ca') == false) {
             \phpCAS::setNoCasServerValidation();

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "jasig/phpcas": "1.3.8",
+        "jasig/phpcas": "1.6.0",
 	"symfony/security-bundle": "~5.0",
 	"symfony/framework-bundle": "~5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "jasig/phpcas": "1.6.0",
+        "apereo/phpcas": "1.6.0",
 	"symfony/security-bundle": "~5.0",
 	"symfony/framework-bundle": "~5.0"
     },


### PR DESCRIPTION
Resolves #30 

We use Symfony to get the base URL of the app. Symfony already has mechanisms to validate the Host is OK (as part of the Framework bundle), or by explicitly calling Request::setTrustedHosts() explicitly if not using the framework bundle.